### PR TITLE
Fixed Vae-Gan Runtime gradient computation problem

### DIFF
--- a/VAE-GAN/VAE-GAN.py
+++ b/VAE-GAN/VAE-GAN.py
@@ -199,7 +199,7 @@ if __name__ == '__main__':
             ###############################################
             vae.zero_grad()
             real_label = torch.ones(batch_size).to(device)  # 定义真实的图片label为1
-            output = D(recon_data)
+            output = D(recon_data.detach())
             errVAE = criterion(output, real_label)
             errVAE.backward()
             D_G_z2 = output.mean().item()


### PR DESCRIPTION
Fixed the issue at [https://github.com/YixinChen-AI/CVAE-GAN-zoos-PyTorch-Beginner/issues/10#issue-2055611981](url)

> RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor [16, 1, 4, 4]] is at version 2; expected version 1 instead. Hint: enable anomaly detection to find the operation that failed to compute its gradient, with torch.autograd.set_detect_anomaly(True).